### PR TITLE
feature/1975-auth-guard

### DIFF
--- a/src/authentication/authentication.controller.ts
+++ b/src/authentication/authentication.controller.ts
@@ -1,5 +1,5 @@
-import { ApiTags, ApiOkResponse } from '@nestjs/swagger';
-import { Post, Controller, Body } from '@nestjs/common';
+import { ApiTags, ApiOkResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { Post, Controller, Body, UseGuards, Delete } from '@nestjs/common';
 
 import { UserDTO } from './../dtos/user.dto';
 import { CredentialsDTO } from './../dtos/credentials.dto';
@@ -7,6 +7,7 @@ import { CredentialsDTO } from './../dtos/credentials.dto';
 import { ClientIP } from './../decorators/client-ip.decorator';
 import { AuthenticationService } from './authentication.service';
 import { ValidateTokenDTO } from '../dtos/validate-token.dto';
+import { AuthGuard } from '../guards/auth.guard';
 
 @ApiTags('Authentication')
 @Controller()
@@ -45,11 +46,16 @@ export class AuthenticationController {
     );
   }
 
-  @Post('/sign-out')
+  @Delete('/sign-out')
+  @UseGuards(AuthGuard)
+  @ApiBearerAuth('Token')
   @ApiOkResponse({
     description: 'Authenticates a user using EPA CDX Services',
   })
-  signOut(@Body() credentials: ValidateTokenDTO, @ClientIP() clientIp: string) {
-    this.service.signOut(credentials.token, clientIp);
+  signOut(
+    @Body() credentials: ValidateTokenDTO,
+    @ClientIP() clientIp: string,
+  ): Promise<void> {
+    return this.service.signOut(credentials.token, clientIp);
   }
 }

--- a/src/authentication/authentication.module.ts
+++ b/src/authentication/authentication.module.ts
@@ -4,9 +4,11 @@ import { ConfigService } from '@nestjs/config';
 import { AuthenticationController } from './authentication.controller';
 import { AuthenticationService } from './authentication.service';
 import { TokenModule } from '../token/token.module';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserSessionRepository } from '../user-session/user-session.repository';
 
 @Module({
-  imports: [TokenModule],
+  imports: [TypeOrmModule.forFeature([UserSessionRepository]), TokenModule],
   controllers: [AuthenticationController],
   providers: [ConfigService, AuthenticationService],
   exports: [AuthenticationService],

--- a/src/authentication/authentication.service.ts
+++ b/src/authentication/authentication.service.ts
@@ -152,6 +152,9 @@ export class AuthenticationService {
     );
     if (sessionStatus.exists) {
       await this.tokenService.removeUserSession(sessionStatus.sessionEntity);
-    } else throw new BadRequestException('No session exists for token.');
+    } else
+      throw new BadRequestException(
+        'No valid session exists for the current user.',
+      );
   }
 }

--- a/src/guards/auth.guard.ts
+++ b/src/guards/auth.guard.ts
@@ -1,0 +1,44 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  BadRequestException,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { UserSessionRepository } from '../user-session/user-session.repository';
+import { InjectRepository } from '@nestjs/typeorm';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  constructor(
+    @InjectRepository(UserSessionRepository)
+    private repository: UserSessionRepository,
+  ) {}
+
+  async validateRequest(request): Promise<boolean> {
+    if (request.headers.authorization === undefined)
+      throw new BadRequestException('Prior Authorization token is required.');
+
+    const splitString = request.headers.authorization.split(' ');
+    if (splitString.lenth !== 2 && splitString[0] !== 'Bearer')
+      throw new BadRequestException('Prior Authorization token is required.');
+
+    const session = await this.repository.findOne({
+      securityToken: splitString[1],
+    });
+
+    if (session === undefined) {
+      throw new BadRequestException('Prior Authorization token is required.');
+    }
+
+    return true;
+  }
+
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const request = context.switchToHttp().getRequest();
+
+    return this.validateRequest(request);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,16 @@ async function bootstrap() {
     .setTitle(`${appTitle} OpenAPI Specification`)
     .setDescription(appDesc)
     .setVersion(`${appVersion} published: ${appPublished}`)
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        name: 'Token',
+        description: 'Enter Auth token',
+        in: 'header',
+      },
+      'Token',
+    )
     .build();
 
   const document = SwaggerModule.createDocument(app, swaggerDocOptions);

--- a/src/token/token.controller.ts
+++ b/src/token/token.controller.ts
@@ -1,9 +1,11 @@
-import { ApiTags, ApiOkResponse } from '@nestjs/swagger';
+import { ApiTags, ApiOkResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { Post, Controller, Body } from '@nestjs/common';
 import { ClientIP } from './../decorators/client-ip.decorator';
 import { UserIdDTO } from '../dtos/user-id.dto';
 import { ValidateTokenDTO } from '../dtos/validate-token.dto';
 import { TokenService } from './token.service';
+import { UseGuards } from '@nestjs/common';
+import { AuthGuard } from '../guards/auth.guard';
 
 @ApiTags('Tokens')
 @Controller()
@@ -11,6 +13,8 @@ export class TokenController {
   constructor(private service: TokenService) {}
 
   @Post()
+  @UseGuards(AuthGuard)
+  @ApiBearerAuth('Token')
   @ApiOkResponse({
     type: String,
     description: 'Creates a security token (user must be authenticated)',

--- a/src/token/token.module.ts
+++ b/src/token/token.module.ts
@@ -5,11 +5,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserSessionRepository } from '../user-session/user-session.repository';
 import { TokenService } from './token.service';
 import { UserSessionMap } from '../maps/user-session.map';
+import { AuthGuard } from '../guards/auth.guard';
 
 @Module({
   imports: [TypeOrmModule.forFeature([UserSessionRepository])],
   controllers: [TokenController],
-  providers: [TokenService, UserSessionMap],
-  exports: [TokenService],
+  providers: [TokenService, UserSessionMap, AuthGuard],
+  exports: [TokenService, AuthGuard],
 })
 export class TokenModule {}

--- a/src/token/token.service.ts
+++ b/src/token/token.service.ts
@@ -71,8 +71,10 @@ export class TokenService {
 
     const tokenExpiration = new Date(Date.now() + 20 * 60000).toUTCString();
     const userSession = await this.getSessionStatus(userId);
-    if (!userSession.exists || userSession.expired) {
-      throw new BadRequestException('No valid user session!');
+    if (!userSession.exists) {
+      throw new BadRequestException(
+        'No valid session exists for the current user.',
+      );
     }
 
     const sessionDTO = userSession.session;

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,7 +1,3 @@
-import { EXPORTDECLARATION_TYPES } from '@babel/types';
-import { Test } from '@nestjs/testing';
-import exp from 'constants';
-import { resourceLimits } from 'worker_threads';
 import { parseToken } from './utils';
 
 describe('Utils', () => {


### PR DESCRIPTION
## Pull Request

Added Auth Guard to the signOut() and createToken() endpoints. This code makes sure an issued bearer token is in use before the methods can be executed. 