### PR TITLE
class-validator-patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   },
   "resolutions": {
     "ansi-regex": "^5.0.1",
+    "class-transformer": "0.4.0",
+    "class-validator": "0.13.1",
     "minimist": "^1.2.6",
     "@xmldom/xmldom": "0.7.7"
   },
@@ -41,7 +43,7 @@
     "@nestjs/typeorm": "8.0.3",
     "@us-epa-camd/easey-common": "11.1.0",
     "class-transformer": "0.4.0",
-    "class-validator": "^0.14.0",
+    "class-validator": "0.13.1",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "js-base64": "^3.7.2",


### PR DESCRIPTION
rolling class-validator back to 0.13.1 since 0.14.0 breaks things