### PR TITLE
Implement and test Responsibility API

### DIFF
--- a/src/permissions/Permissions.service.ts
+++ b/src/permissions/Permissions.service.ts
@@ -183,7 +183,6 @@ export class PermissionsService {
     try {
       const allowLegacyRenegotiationforNodeJsOptions = {
         httpsAgent: new https.Agent({
-          rejectUnauthorized:false,
           secureOptions: crypto.constants.SSL_OP_LEGACY_SERVER_CONNECT,
         }),
       };

--- a/src/permissions/Permissions.service.ts
+++ b/src/permissions/Permissions.service.ts
@@ -1,3 +1,5 @@
+import * as crypto from 'crypto';
+import * as https from 'https';
 import { MockPermissionObject } from './../interfaces/mock-permissions.interface';
 import { HttpService } from '@nestjs/axios';
 import { HttpStatus, Injectable } from '@nestjs/common';
@@ -179,8 +181,15 @@ export class PermissionsService {
     url: string,
   ): Promise<FacilityAccessDTO[]> {
     try {
+      const allowLegacyRenegotiationforNodeJsOptions = {
+        httpsAgent: new https.Agent({
+          rejectUnauthorized:false,
+          secureOptions: crypto.constants.SSL_OP_LEGACY_SERVER_CONNECT,
+        }),
+      };
       const permissionResult = await firstValueFrom(
         this.httpService.get(url, {
+          ...allowLegacyRenegotiationforNodeJsOptions,
           headers: {
             'x-api-key': this.configService.get<string>('app.apiKey'),
             'x-forwarded-for': clientIp,


### PR DESCRIPTION
## Ticket
[Implement and test Responsibility API](https://github.com/US-EPA-CAMD/easey-ui/issues/6025)
## Changes

- Added crypto SSL_OP_LEGACY_SERVER_CONNECT to overcome the EPROTO error