### PR TITLE
add error message when CBS returns Error

### DIFF
--- a/src/permissions/Permissions.service.ts
+++ b/src/permissions/Permissions.service.ts
@@ -203,6 +203,12 @@ export class PermissionsService {
 
       return null;
     } catch (e) {
+      // throwing error, when CBS API returns error.
+      if(!this.configService.get<boolean>('app.mockPermissionsEnabled') && !e.response){
+        throw new EaseyException(new Error(
+          'Unable to obtain user responsibilities from CBS. Please try again later.',
+        ), HttpStatus.INTERNAL_SERVER_ERROR);
+      }
       throw new EaseyException(e, HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }


### PR DESCRIPTION
## Ticket
[Update auth-mgmt/sign-in endpoint to handle situation where CBS responsibilities API is unavailable](https://github.com/US-EPA-CAMD/easey-ui/issues/6106)

## Change

- added error message when the CBS API returns error