### PR TITLE
Remove mock permission setting from manifest-vars.yml

### DIFF
--- a/manifest-vars.yml
+++ b/manifest-vars.yml
@@ -15,5 +15,4 @@ cdxSvcs: https://devngn.epacdxnode.net/cdx-register-II/services
 naasSvcs: https://naasdev.epacdxnode.net/xml/securitytoken_v30.wsdl
 permissionsUrl: https://cbsstagei.epa.gov/CBSD/api/auth-mgmt/responsibilities
 dataFlow: EASEY
-mockPermissionsEnabled: false
 enableAllFacilities: true


### PR DESCRIPTION
Remove mock permission setting from manifest-vars.yml to prevent it from getting overwritten with each deployment