### PR TITLE
fix(6185): account for potentially null values with IsNull() helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@nestjs/platform-express": "^8.4.7",
     "@nestjs/swagger": "^5.1.2",
     "@nestjs/typeorm": "^8.0.3",
-    "@us-epa-camd/easey-common": "17.4.0",
+    "@us-epa-camd/easey-common": "17.4.1",
     "axios": "^1.6.8",
     "class-transformer": "0.4.0",
     "class-validator": "0.14.0",

--- a/src/certifications/certifications.service.ts
+++ b/src/certifications/certifications.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, HttpStatus } from '@nestjs/common';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
-import { EntityManager } from 'typeorm';
+import { EntityManager, IsNull } from 'typeorm';
 
 import { CertificationFacilitiesDTO } from '../dtos/cert-facilities.dto';
 import { CertificationStatementRepository } from './certifications.repository';
@@ -50,7 +50,9 @@ export class CertificationsService {
         let statementData;
 
         if (key === 'null') {
-          statementData = await this.repository.findOneBy({ prgCode: null });
+          statementData = await this.repository.findOneBy({
+            prgCode: IsNull(),
+          });
         } else {
           statementData = await this.repository.findOneBy({ prgCode: key });
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,10 +1251,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@us-epa-camd/easey-common@17.4.0":
-  version "17.4.0"
-  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.4.0/a3de0d7745b292b29fea5aedf961a112e96f109a#a3de0d7745b292b29fea5aedf961a112e96f109a"
-  integrity sha512-KhhdkCArNIYGlgSDOqjx7x0hQm/GEPygJoKIBFWxJ9k7Llrwy2mt+DU4P6wp+LqfdJgfM+7sTzKnSNY4xIjPIQ==
+"@us-epa-camd/easey-common@17.4.1":
+  version "17.4.1"
+  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.4.1/f48111f38d5204b5d7d308a7dffc9c202f0e083e#f48111f38d5204b5d7d308a7dffc9c202f0e083e"
+  integrity sha512-rgU7sceWwUiavS4QDnE4ntLPQJzY8zjK1eT042QJH/UXcHYkE22LQQRW4toU+g4LTknFa3NvvjS3Az52B4vHAA==
   dependencies:
     "@golevelup/ts-jest" "^0.3.4"
     "@nestjs/axios" "0.0.3"


### PR DESCRIPTION
# Main Changes

- `null` is no longer accepted in any of the `find*` methods. The `IsNull()` helper must be used explicitly.
