### PR TITLE
Feature/#6344 add cert statement check on login

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -298,7 +298,7 @@ export class AuthService {
       this.logger.debug('Retrieved user facilities', { facilities });
       this.logger.debug(
         `Retrieved user facilities, number of facilities: ${
-          userDto.facilities ? userDto.facilities.length : 0
+          userDto.facilities.plantList ? userDto.facilities.plantList.length : 0
         }`,
       );
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -296,7 +296,7 @@ export class AuthService {
       );
       //check if the user has any unsigned cert statements
       if (facilities.missingCertificationStatements) {
-        this.logger.error('Login Error: User exist unsigned certitifcate statements');
+        this.logger.error('Login Error: User has unsigned certificate statements');
         //if the user has unsigned cert statements, we need to fail the login
 
         if (!this.bypassService.bypassEnabled()) {

--- a/src/dtos/permissions.dto.ts
+++ b/src/dtos/permissions.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber, IsArray } from 'class-validator';
+import { IsNumber, IsArray, IsBoolean, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
 
 export class FacilityAccessDTO {
   @ApiProperty({
@@ -20,3 +21,20 @@ export class FacilityAccessDTO {
   @IsArray()
   permissions: string[];
 }
+
+export class FacilityAccessWithCertStatementFlagDTO {
+  @ApiProperty({
+    description: 'List of faclities with associated permissions',
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => FacilityAccessDTO)
+  plantList: FacilityAccessDTO[];
+
+  @ApiProperty({
+    description: 'missing unsigned certificate statements flag',
+  })
+  @IsBoolean()
+  missingCertificationStatements: boolean;
+}
+

--- a/src/dtos/user.dto.ts
+++ b/src/dtos/user.dto.ts
@@ -1,5 +1,5 @@
 import { IsArray, IsString, IsBoolean } from 'class-validator';
-import { FacilityAccessWithCertStatementFlagDTO } from './permissions.dto';
+import { FacilityAccessDTO } from './permissions.dto';
 
 export class UserDTO {
   @IsString()
@@ -18,7 +18,9 @@ export class UserDTO {
   refreshToken: string;
   @IsString()
   email: string;
-  facilities: FacilityAccessWithCertStatementFlagDTO;
+  facilities: FacilityAccessDTO[];
+  @IsBoolean()
+  missingCertificationStatements: boolean;
   @IsArray()
   roles: string[];
 }

--- a/src/dtos/user.dto.ts
+++ b/src/dtos/user.dto.ts
@@ -1,5 +1,5 @@
-import { IsArray, IsString } from 'class-validator';
-import { FacilityAccessDTO } from './permissions.dto';
+import { IsArray, IsString, IsBoolean } from 'class-validator';
+import { FacilityAccessWithCertStatementFlagDTO } from './permissions.dto';
 
 export class UserDTO {
   @IsString()
@@ -18,7 +18,7 @@ export class UserDTO {
   refreshToken: string;
   @IsString()
   email: string;
-  facilities: FacilityAccessDTO[];
+  facilities: FacilityAccessWithCertStatementFlagDTO;
   @IsArray()
   roles: string[];
 }

--- a/src/interfaces/mock-permissions.interface.ts
+++ b/src/interfaces/mock-permissions.interface.ts
@@ -7,6 +7,6 @@ export interface MockPermissions {
 export interface MockPermissionObject {
   userId: string;
   isAdmin?: boolean;
-  plantList: MockPermissions[];
+  facilities: MockPermissions[];
   missingCertificationStatements: boolean;
 }

--- a/src/interfaces/mock-permissions.interface.ts
+++ b/src/interfaces/mock-permissions.interface.ts
@@ -7,5 +7,6 @@ export interface MockPermissions {
 export interface MockPermissionObject {
   userId: string;
   isAdmin?: boolean;
-  facilities: MockPermissions[];
+  plantList: MockPermissions[];
+  missingCertificationStatements: boolean;
 }

--- a/src/permissions/Permissions.controller.ts
+++ b/src/permissions/Permissions.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Query } from '@nestjs/common';
 
 import { ApiTags, ApiOkResponse, ApiSecurity } from '@nestjs/swagger';
-import { FacilityAccessDTO } from '../dtos/permissions.dto';
+import { FacilityAccessWithCertStatementFlagDTO } from '../dtos/permissions.dto';
 import { PermissionsService } from './Permissions.service';
 
 @Controller()
@@ -12,12 +12,12 @@ export class PermissionsController {
 
   @Get('permissions')
   @ApiOkResponse({
-    type: FacilityAccessDTO,
-    description: 'Gets mocked permissions for provided user',
+    type: FacilityAccessWithCertStatementFlagDTO,
+    description: 'Gets mocked permissions and flag for unassigned certificate statements for provided user',
   })
   getPermissions(
     @Query('userId') userId: string,
-  ): Promise<FacilityAccessDTO[]> {
+  ): Promise<FacilityAccessWithCertStatementFlagDTO> {
     return this.service.getMockPermissions(userId);
   }
 }

--- a/src/permissions/Permissions.service.spec.ts
+++ b/src/permissions/Permissions.service.spec.ts
@@ -32,7 +32,7 @@ const client = {
 
 jest.mock('rxjs', () => ({
   firstValueFrom: jest.fn().mockResolvedValue({
-    data: [
+    data: 
       {
         userId: 'user',
         isAdmin: true,
@@ -48,7 +48,6 @@ jest.mock('rxjs', () => ({
         ],
         missingCertificationStatements: true,
       },
-    ],
   }),
 }));
 describe('PermissionsService', () => {
@@ -122,7 +121,7 @@ describe('PermissionsService', () => {
   describe('getUserPermissions', () => {
     it('should return mocked user permissions', async () => {
       const permissions = await service.getUserPermissions('', '', '');
-      expect(permissions).toEqual([
+      expect(permissions).toEqual(
         {
           userId: 'user',
           isAdmin: true,
@@ -138,7 +137,7 @@ describe('PermissionsService', () => {
           ], 
           missingCertificationStatements: true,
         },
-      ]);
+      );
     });
   });
 
@@ -214,7 +213,7 @@ describe('PermissionsService', () => {
     it('should parse user env var and build the permissions properly given a found user', async () => {
       const p: MockPermissionObject = {
         userId: 'user',
-        plantList: [{ orisCode: 1, roles: [], facId: 1 }],
+        facilities: [{ orisCode: 1, roles: [], facId: 1 }],
         missingCertificationStatements: true,
       };
       jest.spyOn(service, 'getMockPermissionObject').mockResolvedValue([p]);
@@ -231,7 +230,7 @@ describe('PermissionsService', () => {
     it('should parse user env var and build the permissions properly given a not found user', async () => {
       const p: MockPermissionObject = {
         userId: 'user',
-        plantList: [{ orisCode: 1, roles: [], facId: 1 }],
+        facilities: [{ orisCode: 1, roles: [], facId: 1 }],
         missingCertificationStatements: true,
       };
       responseVals = {

--- a/src/permissions/Permissions.service.spec.ts
+++ b/src/permissions/Permissions.service.spec.ts
@@ -188,7 +188,11 @@ describe('PermissionsService', () => {
 
   describe('retrieveAllUserFacilities', () => {
     it('should return all facilities for the user given mocked data', async () => {
-      jest.spyOn(service, 'getUserPermissions').mockResolvedValue(new FacilityAccessWithCertStatementFlagDTO());
+      const p: FacilityAccessWithCertStatementFlagDTO = {
+        plantList: [],
+        missingCertificationStatements: true,
+      };
+      jest.spyOn(service, 'getUserPermissions').mockResolvedValue(p);
 
       const facilities = await service.retrieveAllUserFacilities(
         '',
@@ -196,7 +200,8 @@ describe('PermissionsService', () => {
         '',
         '',
       );
-      expect(facilities).toEqual(new FacilityAccessWithCertStatementFlagDTO());
+      expect(facilities?.plantList).toEqual([]);
+      expect(facilities?.missingCertificationStatements).toEqual(true);
     });
   });
 

--- a/src/permissions/Permissions.service.spec.ts
+++ b/src/permissions/Permissions.service.spec.ts
@@ -212,7 +212,7 @@ describe('PermissionsService', () => {
         plantList: [{ orisCode: 1, roles: [], facId: 1 }],
         missingCertificationStatements: true,
       };
-      jest.spyOn(service, 'getMockPermissionObject').mockResolvedValue(p);
+      jest.spyOn(service, 'getMockPermissionObject').mockResolvedValue([p]);
       responseVals = {
         ...responseVals,
         ['app.env']: 'local-dev',
@@ -234,7 +234,7 @@ describe('PermissionsService', () => {
         ['app.env']: 'local-dev',
       };
 
-      jest.spyOn(service, 'getMockPermissionObject').mockResolvedValue(p);
+      jest.spyOn(service, 'getMockPermissionObject').mockResolvedValue([p]);
 
       const permissions = await service.getMockPermissions('userNotFound');
 

--- a/src/permissions/Permissions.service.ts
+++ b/src/permissions/Permissions.service.ts
@@ -148,14 +148,19 @@ export class PermissionsService {
 
     const permissionsDto = new FacilityAccessWithCertStatementFlagDTO();
     const mockPermissionObject = await this.getMockPermissionObject();
-    mockPermissionObject.userId = mockPermissionObject.userId.toUpperCase();
-    const userPermissions = mockPermissionObject;
+
+    //filter out all the unmactched records
+    const userPermissions = mockPermissionObject.filter(
+      entry => entry.userId.toUpperCase() === userId.toUpperCase(),
+    );
+    
+    //only retrieve info from the first matched record
     if (
-      userPermissions.plantList != null &&
-      userPermissions.plantList.length > 0
+      userPermissions[0]?.plantList != null &&
+      userPermissions[0]?.plantList.length > 0
     ) {
       const plantList = []
-      for (const facility of userPermissions.plantList) {
+      for (const facility of userPermissions[0]?.plantList) {
         const dto = new FacilityAccessDTO();
         dto.facId = facility.facId;
         dto.orisCode = facility.orisCode;
@@ -163,7 +168,7 @@ export class PermissionsService {
         plantList.push(dto);
       };
       permissionsDto.plantList = plantList;
-      permissionsDto.missingCertificationStatements = userPermissions.missingCertificationStatements;
+      permissionsDto.missingCertificationStatements = userPermissions[0]?.missingCertificationStatements;
     } else if (this.configService.get<boolean>('app.enableAllFacilities')) {
       return null;
     }
@@ -217,7 +222,7 @@ export class PermissionsService {
     }
   }
 
-  async getMockPermissionObject(): Promise<MockPermissionObject> {
+  async getMockPermissionObject(): Promise<MockPermissionObject[]> {
     const contentUri = this.configService.get<string>('app.contentUri');
     try {
       const url = `${contentUri}/auth/mockPermissions.json`;

--- a/src/permissions/Permissions.service.ts
+++ b/src/permissions/Permissions.service.ts
@@ -156,11 +156,11 @@ export class PermissionsService {
     
     //only retrieve info from the first matched record
     if (
-      userPermissions[0]?.plantList != null &&
-      userPermissions[0]?.plantList.length > 0
+      userPermissions.length > 0 &&
+      userPermissions[0].plantList?.length > 0
     ) {
       const plantList = []
-      for (const facility of userPermissions[0]?.plantList) {
+      for (const facility of userPermissions[0].plantList) {
         const dto = new FacilityAccessDTO();
         dto.facId = facility.facId;
         dto.orisCode = facility.orisCode;

--- a/src/permissions/Permissions.service.ts
+++ b/src/permissions/Permissions.service.ts
@@ -157,10 +157,10 @@ export class PermissionsService {
     //only retrieve info from the first matched record
     if (
       userPermissions.length > 0 &&
-      userPermissions[0].plantList?.length > 0
+      userPermissions[0].facilities?.length > 0
     ) {
       const plantList = []
-      for (const facility of userPermissions[0].plantList) {
+      for (const facility of userPermissions[0].facilities) {
         const dto = new FacilityAccessDTO();
         dto.facId = facility.facId;
         dto.orisCode = facility.orisCode;
@@ -168,7 +168,9 @@ export class PermissionsService {
         plantList.push(dto);
       };
       permissionsDto.plantList = plantList;
-      permissionsDto.missingCertificationStatements = userPermissions[0]?.missingCertificationStatements;
+      //if the missingCertificationStatements flag is null or undefined, set the default value to true
+      permissionsDto.missingCertificationStatements = userPermissions[0]?.missingCertificationStatements == null ? true : userPermissions[0]?.missingCertificationStatements;
+    
     } else if (this.configService.get<boolean>('app.enableAllFacilities')) {
       return null;
     }
@@ -199,7 +201,10 @@ export class PermissionsService {
       );
 
       if (permissionResult.data) {
-        return permissionResult.data;
+        const data = permissionResult.data
+        // check if the missingCertificationStatements is null or undefined, if it is, then set the default value to true
+        data.missingCertificationStatements = data.missingCertificationStatements == null ? true : data.missingCertificationStatements; 
+        return data;
       }
 
       return null;

--- a/src/permissions/Permissions.service.ts
+++ b/src/permissions/Permissions.service.ts
@@ -116,7 +116,7 @@ export class PermissionsService {
 
     if (!hasRequiredRole) {
       this.logger.debug('User does not have one of the required roles. Returning an empty list of responsibilities. ');
-      return new FacilityAccessWithCertStatementFlagDTO();
+      return { plantList: [], missingCertificationStatements: true,} as FacilityAccessWithCertStatementFlagDTO;
     }
 
     let url: string;
@@ -146,7 +146,7 @@ export class PermissionsService {
       );
     }
 
-    const permissionsDto = new FacilityAccessWithCertStatementFlagDTO();
+    const permissionsDto = {plantList: [], missingCertificationStatements: true,} as FacilityAccessWithCertStatementFlagDTO;
     const mockPermissionObject = await this.getMockPermissionObject();
 
     //filter out all the unmactched records

--- a/src/token/token.service.spec.ts
+++ b/src/token/token.service.spec.ts
@@ -60,7 +60,7 @@ describe('Token Service', () => {
             isSessionTokenExpired: jest.fn().mockReturnValue(false),
             getUserPermissions: jest
               .fn()
-              .mockResolvedValue(new FacilityAccessWithCertStatementFlagDTO()),
+              .mockResolvedValue({plantList: [], missingCertificationStatements: true, }as FacilityAccessWithCertStatementFlagDTO),
           }),
         },
         {
@@ -84,7 +84,7 @@ describe('Token Service', () => {
           provide: PermissionsService,
           useFactory: () => ({
             retrieveAllUserRoles: jest.fn().mockResolvedValue(['Preparer']),
-            retrieveAllUserFacilities: jest.fn().mockResolvedValue(new FacilityAccessWithCertStatementFlagDTO()),
+            retrieveAllUserFacilities: jest.fn().mockResolvedValue({plantList: [], missingCertificationStatements: true, } as FacilityAccessWithCertStatementFlagDTO),
           }),
         },
         TokenService,

--- a/src/token/token.service.spec.ts
+++ b/src/token/token.service.spec.ts
@@ -4,7 +4,7 @@ import { LoggerModule } from '@us-epa-camd/easey-common/logger';
 import { UserSessionService } from '../user-session/user-session.service';
 import { TokenDTO } from '../dtos/token.dto';
 import { TokenService } from './token.service';
-import { FacilityAccessDTO } from '../dtos/permissions.dto';
+import { FacilityAccessWithCertStatementFlagDTO } from '../dtos/permissions.dto';
 import { PermissionsService } from '../permissions/Permissions.service';
 import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 import { BypassService } from '../oidc/Bypass.service';
@@ -60,7 +60,7 @@ describe('Token Service', () => {
             isSessionTokenExpired: jest.fn().mockReturnValue(false),
             getUserPermissions: jest
               .fn()
-              .mockResolvedValue([new FacilityAccessDTO()]),
+              .mockResolvedValue(new FacilityAccessWithCertStatementFlagDTO()),
           }),
         },
         {
@@ -84,7 +84,7 @@ describe('Token Service', () => {
           provide: PermissionsService,
           useFactory: () => ({
             retrieveAllUserRoles: jest.fn().mockResolvedValue(['Preparer']),
-            retrieveAllUserFacilities: jest.fn().mockResolvedValue([]),
+            retrieveAllUserFacilities: jest.fn().mockResolvedValue(new FacilityAccessWithCertStatementFlagDTO()),
           }),
         },
         TokenService,


### PR DESCRIPTION
## Pull Request

```

- Added FacilityAccessWithCertStatementFlagDTO to permissions.dto to cope with the updates of user responsibility response from auth-mgmt/responsiblities?userId= endpoint, update other related DTOs like UserDTO, updated affected service methods.
- Added missing certificate statement checking and error thrown logic in AuthService.signIn(), to display error message and stop the sign in process.
- Updated mock-permissions interface to include the missingCertificationStatements flag.
- Updated affected tests.

```
