### PR TITLE
Update package.json to use tilde for easey-common versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@nestjs/platform-express": "^8.4.7",
     "@nestjs/swagger": "^5.1.2",
     "@nestjs/typeorm": "^8.0.3",
-    "@us-epa-camd/easey-common": "17.4.1",
+    "@us-epa-camd/easey-common": "~17.8.2",
     "axios": "^1.7.4",
     "class-transformer": "0.4.0",
     "class-validator": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@nestjs/platform-express": "^8.4.7",
     "@nestjs/swagger": "^5.1.2",
     "@nestjs/typeorm": "^8.0.3",
-    "@us-epa-camd/easey-common": "~17.8.2",
+    "@us-epa-camd/easey-common": "~17.4.1",
     "axios": "^1.7.4",
     "class-transformer": "0.4.0",
     "class-validator": "0.14.0",


### PR DESCRIPTION
change the versioning for easey-common dependency to use tilde to avoid picking up anything but minor updates