### PR TITLE
Fix/#6724 remove app status

### DIFF
--- a/manifest-vars.beta.yml
+++ b/manifest-vars.beta.yml
@@ -8,7 +8,6 @@ permissionsUrl: https://cbsprodbeta.epa.gov/CBS/api/auth-mgmt/responsibilities
 dataFlow: EASEY Beta
 enableAllFacilities: false
 mockPermissionsEnabled: false
-appStatus: ONLINE
 maintenanceBypassUsers: '[]'
 enableAuditLog: true
 

--- a/manifest-vars.perf.yml
+++ b/manifest-vars.perf.yml
@@ -9,7 +9,6 @@ permissionsUrl: https://cbsstagei.epa.gov/CBSD/api/auth-mgmt/responsibilities
 dataFlow: EASEY Performance
 mockPermissionsEnabled: false
 enableAllFacilities: true
-appStatus: ONLINE
 maintenanceBypassUsers: '[]'
 enableAuditLog: true
 

--- a/manifest-vars.prod.yml
+++ b/manifest-vars.prod.yml
@@ -7,7 +7,6 @@ naasSvcs: https://cdxnodenaas.epa.gov/xml/securitytoken_v30.wsdl
 permissionsUrl: https://camd.epa.gov/CBS/api/auth-mgmt/responsibilities
 mockPermissionsEnabled: false
 enableAllFacilities: false
-appStatus: ONLINE
 maintenanceBypassUsers: '[]'
 enableAuditLog: true
 

--- a/manifest-vars.staging.yml
+++ b/manifest-vars.staging.yml
@@ -8,7 +8,6 @@ permissionsUrl: https://cbsstagei.epa.gov/CBS/api/auth-mgmt/responsibilities
 dataFlow: EASEY Staging
 mockPermissionsEnabled: false
 enableAllFacilities: false
-appStatus: ONLINE
 maintenanceBypassUsers: '[]'
 enableAuditLog: true
 

--- a/manifest-vars.test.yml
+++ b/manifest-vars.test.yml
@@ -6,7 +6,6 @@ cdxSvcs: https://testngn.epacdxnode.net/cdx-register-II/services
 naasSvcs: https://naas.epacdxnode.net/xml/securitytoken_v30.wsdl
 permissionsUrl: https://cbsstagei.epa.gov/CBS/api/auth-mgmt/responsibilities
 dataFlow: EASEY Test
-appStatus: ONLINE
 maintenanceBypassUsers: '[]'
 enableAuditLog: true
 

--- a/manifest-vars.yml
+++ b/manifest-vars.yml
@@ -17,7 +17,6 @@ permissionsUrl: https://cbsstagei.epa.gov/CBSD/api/auth-mgmt/responsibilities
 dataFlow: EASEY
 mockPermissionsEnabled: false
 enableAllFacilities: true
-appStatus: ONLINE
 maintenanceBypassUsers: '[]'
 enableAuditLog: true
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -37,8 +37,6 @@ applications:
       EASEY_AUTH_API_DATA_FLOW: ((dataFlow))
       EASEY_AUTH_API_ENABLE_ALL_FACILITIES: ((enableAllFacilities))
       TZ: America/New_York
-      EASEY_AUTH_API_APP_STATUS: ((appStatus))
-      EASEY_MAINTENANCE_BYPASS_USERS: ((maintenanceBypassUsers))
       EASEY_AUTH_API_ENABLE_AUDIT_LOG: ((enableAuditLog))
 
       # ICAM

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -106,7 +106,7 @@ export default registerAs('app', () => ({
   ),
   appStatus: getConfigValue(
     'EASEY_AUTH_API_APP_STATUS',
-    'ONLINE',
+    'DOWN',
   ),
   authApi: {
     uri: getConfigValue('EASEY_AUTH_API', `https://${apiHost}/auth-mgmt`),


### PR DESCRIPTION
## Ticket
[Remove Setting of EASEY_AUTH_API_APP_STATUS During auth-api Deployment](https://github.com/US-EPA-CAMD/easey-ui/issues/6724)

## Change

- Remove the `appStatus` setting from the manifest-vars-****.yml files
- Change the default value set in `app.config.ts` to `DOWN`
- Remove the `EASEY_MAINTENANCE_BYPASS_USERS` and `EASEY_AUTH_API_APP_STATUS`  setting from manifest.yml