### PR TITLE
fix/#6684 Admin Tools Available for Non-Admin EPA Users

### DIFF
--- a/src/dtos/oidc-auth-dtos.ts
+++ b/src/dtos/oidc-auth-dtos.ts
@@ -2,6 +2,7 @@ import { JwtPayload } from 'jsonwebtoken';
 
 // Minimal interface for API response that contains only the necessary role description
 export interface UserRole {
+  dataflow: string;
   status: {
     code: string;
   };

--- a/src/permissions/Permissions.service.spec.ts
+++ b/src/permissions/Permissions.service.spec.ts
@@ -156,7 +156,7 @@ describe('PermissionsService', () => {
     it('should return roles for the user', async () => {
       client.RetrieveRolesAsync = jest.fn().mockResolvedValue([
         {
-          Role: [{ status: { code: 'Active' }, type: { description: 'Mock' } }],
+          Role: [{ dataflow: 'flow', status: { code: 'Active' }, type: { description: 'Mock' } }],
         },
       ]);
       const roles = await service.getUserRoles('', 0, '');

--- a/src/permissions/Permissions.service.ts
+++ b/src/permissions/Permissions.service.ts
@@ -62,9 +62,10 @@ export class PermissionsService {
         UserRolesResponse
       >(apiUrl, apiToken, null);
 
+      const dataflow = this.configService.get<string>('app.dataFlow');
       if (res && res.length > 0) {
         const activeDescriptions = res
-          .filter(role => role.status.code === 'Active')
+          .filter(role => role.dataflow === dataflow && role.status.code === 'Active')
           .map(role => role.type.description);
         return activeDescriptions;
       }


### PR DESCRIPTION
### **Related Ticket:**

- ticket [#6684](https://github.com/US-EPA-CAMD/easey-ui/issues/6684)

### **Updates:**

- Updated PermissionsService.getUserRoles to filter active roles with the matched dataflow.
- Updated the related DTO.
- Updated the related unit test.