### PR TITLE
#6809 add ability to mock CDX role to bypass logic

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -170,7 +170,7 @@ export class AuthService {
       if (this.bypassService.bypassEnabled()) {
         this.logger.debug('Bypass is enabled');
         //For bypass, sessionId has the userID
-        userDto = this.bypassService.getBypassUser(signInDto.sessionId);
+        userDto = await this.bypassService.getBypassUser(signInDto.sessionId);
 
         this.validateUserMaintenanceAblity(userDto);
 

--- a/src/interfaces/mock-permissions.interface.ts
+++ b/src/interfaces/mock-permissions.interface.ts
@@ -9,4 +9,5 @@ export interface MockPermissionObject {
   isAdmin?: boolean;
   facilities: MockPermissions[];
   missingCertificationStatements: boolean;
+  roles?: string[];
 }

--- a/src/oidc/Bypass.service.spec.ts
+++ b/src/oidc/Bypass.service.spec.ts
@@ -1,13 +1,10 @@
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { LoggerModule } from '@us-epa-camd/easey-common/logger';
-import { PermissionsService } from './Permissions.service';
 import { HttpService } from '@nestjs/axios';
 import { MockPermissionObject } from './../interfaces/mock-permissions.interface';
-import { SignService } from '../sign/Sign.service';
 import { UserSessionService } from '../user-session/user-session.service';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
-import { OidcHelperService } from '../oidc/OidcHelperService';
 import { BypassService } from '../oidc/Bypass.service';
 import { FacilityAccessWithCertStatementFlagDTO } from '../dtos/permissions.dto';
 import { UserRole } from '@us-epa-camd/easey-common/enums';

--- a/src/oidc/Bypass.service.spec.ts
+++ b/src/oidc/Bypass.service.spec.ts
@@ -87,8 +87,8 @@ describe('BypassService', () => {
 
       const roles = await service.getMockRoles('user');
 
-      expect(roles.length.toEqual(1);
-	  expect(roles[0] === 1;
+      expect(roles.length === 1);
+	  expect(roles[0].toEqual(UserRole.PREPARER);
     });
 
     it('should parse user env var and build the permissions properly given a not found user', async () => {
@@ -107,7 +107,7 @@ describe('BypassService', () => {
 
       const roles = await service.getMockRoles('userNotFound');
 	
-	  expect(roles.length === 6;
+	  expect(roles.length === 6);
 		
     });
   });

--- a/src/oidc/Bypass.service.spec.ts
+++ b/src/oidc/Bypass.service.spec.ts
@@ -1,0 +1,133 @@
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { LoggerModule } from '@us-epa-camd/easey-common/logger';
+import { PermissionsService } from './Permissions.service';
+import { HttpService } from '@nestjs/axios';
+import { MockPermissionObject } from './../interfaces/mock-permissions.interface';
+import { SignService } from '../sign/Sign.service';
+import { UserSessionService } from '../user-session/user-session.service';
+import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
+import { OidcHelperService } from '../oidc/OidcHelperService';
+import { BypassService } from '../oidc/Bypass.service';
+import { FacilityAccessWithCertStatementFlagDTO } from '../dtos/permissions.dto';
+import { UserRole } from '@us-epa-camd/easey-common/enums';
+
+let responseVals = {
+  ['app.env']: 'production',
+  ['app.contentUri']: 'contentUri',
+  ['app.cdxSvcs']: '',
+  ['app.mockPermissionsEnabled']: true,
+  ['app.enableAllFacilities']: true,
+};
+
+jest.mock('soap', () => ({
+  createClientAsync: jest.fn(() => Promise.resolve(client)),
+}));
+
+const client = {
+  RetrieveRolesAsync: jest.fn(),
+  RetrieveOrganizationsAsync: jest.fn().mockResolvedValue({
+    email: 'user@example.com',
+  }),
+};
+
+jest.mock('rxjs', () => {
+  const originalModule = jest.requireActual('rxjs');
+  return {
+    ...originalModule,
+    firstValueFrom: jest.fn().mockResolvedValue({
+      data: {
+        userId: 'user',
+        isAdmin: true,
+        plantList: [
+          {
+            id: 1,
+            permissions: ['DSMP', 'DSEM', 'DSQA'],
+          },
+          {
+            id: 2,
+            permissions: ['DSMP', 'DSEM'],
+          },
+        ],
+        missingCertificationStatements: true,
+		roles: [UserRole.PREPARER],
+      },
+    }),
+  };
+});
+describe('BypassService', () => {
+  let service: BypassService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [LoggerModule],
+      providers: [
+        BypassService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              return responseVals[key];
+            }),
+          },
+        },
+        {
+          provide: HttpService,
+          useFactory: () => ({
+            get: jest.fn(),
+          }),
+        },
+      ],
+    }).compile();
+
+    service = module.get<BypassService>(BypassService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getMockPermissions', () => {
+    it('should error in production', async () => {
+      await expect(service.getMockPermissions('')).rejects.toThrowError(
+        EaseyException,
+      );
+    });
+    it('should parse user env var and build the permissions properly given a found user', async () => {
+      const p: MockPermissionObject = {
+        userId: 'user',
+        facilities: [{ orisCode: 1, roles: [], facId: 1 }],
+        missingCertificationStatements: true,
+		roles: [UserRole.PREPARER],
+      };
+      jest.spyOn(service, 'getMockPermissionObject').mockResolvedValue([p]);
+      responseVals = {
+        ...responseVals,
+        ['app.env']: 'local-dev',
+      };
+
+      const permissions = await service.getMockPermissions('user');
+
+      expect(permissions.plantList[0].facId).toEqual(1);
+    });
+
+    it('should parse user env var and build the permissions properly given a not found user', async () => {
+      const p: MockPermissionObject = {
+        userId: 'user',
+        facilities: [{ orisCode: 1, roles: [], facId: 1 }],
+        missingCertificationStatements: true,
+		roles: [UserRole.PREPARER],
+      };
+      responseVals = {
+        ...responseVals,
+        ['app.env']: 'local-dev',
+      };
+
+      jest.spyOn(service, 'getMockPermissionObject').mockResolvedValue([p]);
+
+      const permissions = await service.getMockPermissions('userNotFound');
+
+      expect(permissions).toBe(null);
+    });
+  });
+});

--- a/src/oidc/Bypass.service.spec.ts
+++ b/src/oidc/Bypass.service.spec.ts
@@ -3,11 +3,9 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { LoggerModule } from '@us-epa-camd/easey-common/logger';
 import { HttpService } from '@nestjs/axios';
 import { MockPermissionObject } from './../interfaces/mock-permissions.interface';
-import { UserSessionService } from '../user-session/user-session.service';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { BypassService } from '../oidc/Bypass.service';
 import { FacilityAccessWithCertStatementFlagDTO } from '../dtos/permissions.dto';
-import { UserRole } from '@us-epa-camd/easey-common/enums';
 
 let responseVals = {
   ['app.env']: 'production',
@@ -17,17 +15,6 @@ let responseVals = {
   ['app.enableAllFacilities']: true,
 };
 
-jest.mock('soap', () => ({
-  createClientAsync: jest.fn(() => Promise.resolve(client)),
-}));
-
-const client = {
-  RetrieveRolesAsync: jest.fn(),
-  RetrieveOrganizationsAsync: jest.fn().mockResolvedValue({
-    email: 'user@example.com',
-  }),
-};
-
 jest.mock('rxjs', () => {
   const originalModule = jest.requireActual('rxjs');
   return {
@@ -35,7 +22,7 @@ jest.mock('rxjs', () => {
     firstValueFrom: jest.fn().mockResolvedValue({
       data: {
         userId: 'user',
-        isAdmin: true,
+        isAdmin: false,
         plantList: [
           {
             id: 1,
@@ -47,7 +34,6 @@ jest.mock('rxjs', () => {
           },
         ],
         missingCertificationStatements: true,
-		roles: [UserRole.PREPARER],
       },
     }),
   };
@@ -84,12 +70,7 @@ describe('BypassService', () => {
     expect(service).toBeDefined();
   });
 
-  describe('getMockPermissions', () => {
-    it('should error in production', async () => {
-      await expect(service.getMockPermissions('')).rejects.toThrowError(
-        EaseyException,
-      );
-    });
+  describe('getMockRoles', () => {
     it('should parse user env var and build the permissions properly given a found user', async () => {
       const p: MockPermissionObject = {
         userId: 'user',
@@ -103,9 +84,10 @@ describe('BypassService', () => {
         ['app.env']: 'local-dev',
       };
 
-      const permissions = await service.getMockPermissions('user');
+      const roles = await service.getMockRoles('user');
 
-      expect(permissions.plantList[0].facId).toEqual(1);
+      expect(roles.length.toEqual(1);
+	  expect(roles[0].toEqual(UserRole.PREPARER);
     });
 
     it('should parse user env var and build the permissions properly given a not found user', async () => {
@@ -122,9 +104,10 @@ describe('BypassService', () => {
 
       jest.spyOn(service, 'getMockPermissionObject').mockResolvedValue([p]);
 
-      const permissions = await service.getMockPermissions('userNotFound');
-
-      expect(permissions).toBe(null);
+      const roles = await service.getMockRoles('userNotFound');
+	
+	  expect(roles.length.toEqual(6);
+		
     });
   });
 });

--- a/src/oidc/Bypass.service.spec.ts
+++ b/src/oidc/Bypass.service.spec.ts
@@ -6,6 +6,7 @@ import { MockPermissionObject } from './../interfaces/mock-permissions.interface
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { BypassService } from '../oidc/Bypass.service';
 import { FacilityAccessWithCertStatementFlagDTO } from '../dtos/permissions.dto';
+import { UserRole } from '@us-epa-camd/easey-common/enums';
 
 let responseVals = {
   ['app.env']: 'production',
@@ -87,7 +88,7 @@ describe('BypassService', () => {
       const roles = await service.getMockRoles('user');
 
       expect(roles.length.toEqual(1);
-	  expect(roles[0].toEqual(UserRole.PREPARER);
+	  expect(roles[0] === 1;
     });
 
     it('should parse user env var and build the permissions properly given a not found user', async () => {
@@ -106,7 +107,7 @@ describe('BypassService', () => {
 
       const roles = await service.getMockRoles('userNotFound');
 	
-	  expect(roles.length.toEqual(6);
+	  expect(roles.length === 6;
 		
     });
   });

--- a/src/oidc/Bypass.service.spec.ts
+++ b/src/oidc/Bypass.service.spec.ts
@@ -88,7 +88,7 @@ describe('BypassService', () => {
       const roles = await service.getMockRoles('user');
 
       expect(roles.length === 1);
-	  expect(roles[0].toEqual(UserRole.PREPARER);
+	  expect(roles[0] === UserRole.PREPARER);
     });
 
     it('should parse user env var and build the permissions properly given a not found user', async () => {

--- a/src/oidc/Bypass.service.spec.ts
+++ b/src/oidc/Bypass.service.spec.ts
@@ -23,8 +23,7 @@ jest.mock('rxjs', () => {
     firstValueFrom: jest.fn().mockResolvedValue({
       data: {
         userId: 'user',
-        isAdmin: false,
-        plantList: [
+        facilities: [
           {
             id: 1,
             permissions: ['DSMP', 'DSEM', 'DSQA'],

--- a/src/oidc/Bypass.service.ts
+++ b/src/oidc/Bypass.service.ts
@@ -113,14 +113,14 @@ export class BypassService {
   
   async getMockRoles(userId: string): Promise<string[]> {
     
-	const mockPermissionObject = await this.getMockPermissionObject();
+    const mockPermissionObject = await this.getMockPermissionObject();
     
-	//Filter out all the unmatched records
+    //Filter out all the unmatched records
     const userPermissions = mockPermissionObject.filter(
       (entry) => entry.userId.toUpperCase() === userId.toUpperCase(),
     );
     
-	//Only retrieve info from the first matched record
+    //Only retrieve info from the first matched record
     if (userPermissions.length > 0 && userPermissions[0]?.roles?.length > 0) {
       //Test roles are defined for this user
       // return test roles

--- a/src/oidc/Bypass.service.ts
+++ b/src/oidc/Bypass.service.ts
@@ -10,7 +10,7 @@ import { decode, encode } from 'js-base64';
 import { TokenDTO } from '../dtos/token.dto';
 import { UserDTO } from '../dtos/user.dto';
 
-import { MockPermissionObject } from '/../interfaces/mock-permissions.interface';
+import { MockPermissionObject } from './../interfaces/mock-permissions.interface';
 
 @Injectable()
 export class BypassService {

--- a/src/oidc/Bypass.service.ts
+++ b/src/oidc/Bypass.service.ts
@@ -50,7 +50,7 @@ export class BypassService {
     user.email = this.configService.get<string>('cdxBypass.userEmail');
     user.lastName = '';
 	
-    user.roles = await this.getMockRoles();
+    user.roles = this.getMockRoles();
 
     return user;
   }

--- a/src/oidc/Bypass.service.ts
+++ b/src/oidc/Bypass.service.ts
@@ -32,7 +32,7 @@ export class BypassService {
     return this.bypass;
   }
 
-  getBypassUser(userId: string) {
+  async getBypassUser(userId: string): Promise<UserDTO> {
     //Handle bypass sign in if enabled
     const acceptedUsers = JSON.parse(
       this.configService.get<string>('cdxBypass.users'),
@@ -53,7 +53,7 @@ export class BypassService {
     user.email = this.configService.get<string>('cdxBypass.userEmail');
     user.lastName = '';
 	
-    user.roles = this.getMockRoles(userId);
+    user.roles = await this.getMockRoles(userId);
 
     return user;
   }
@@ -127,7 +127,7 @@ export class BypassService {
     ) {
       //test roles are defined for this user
 	  // return test roles
-	  return userPermissions[0].roles as string[];
+	  return userPermissions[0].roles;
     }
 	else {		
 	  //test roles are not defined for this user
@@ -139,7 +139,7 @@ export class BypassService {
 		UserRole.ANALYST,
 		UserRole.ADMIN,
 		UserRole.INITIAL_AUTHORIZER,
-	  ] as string[];
+	  ];
 	}
   }
 

--- a/src/oidc/Bypass.service.ts
+++ b/src/oidc/Bypass.service.ts
@@ -1,3 +1,4 @@
+import { HttpService } from '@nestjs/axios';
 import { HttpStatus, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { UserRole } from '@us-epa-camd/easey-common/enums';
@@ -108,7 +109,7 @@ export class BypassService {
     return user;
   }
   
-  async getMockRoles(userId: string): Promise<Array<string>> {
+  async getMockRoles(userId: string): Promise<string[]> {
 	  
 	const mockPermissionObject = await this.getMockPermissionObject();
 	

--- a/src/oidc/Bypass.service.ts
+++ b/src/oidc/Bypass.service.ts
@@ -50,7 +50,7 @@ export class BypassService {
     user.email = this.configService.get<string>('cdxBypass.userEmail');
     user.lastName = '';
 	
-    user.roles = this.getMockRoles();
+    user.roles = this.getMockRoles(userId);
 
     return user;
   }
@@ -108,7 +108,7 @@ export class BypassService {
     return user;
   }
   
-  async getMockRoles(): Promise<Array<string>> {
+  async getMockRoles(userId: string): Promise<Array<string>> {
 	  
 	const mockPermissionObject = await this.getMockPermissionObject();
 	

--- a/src/oidc/Bypass.service.ts
+++ b/src/oidc/Bypass.service.ts
@@ -12,6 +12,7 @@ import { TokenDTO } from '../dtos/token.dto';
 import { UserDTO } from '../dtos/user.dto';
 
 import { MockPermissionObject } from './../interfaces/mock-permissions.interface';
+import { firstValueFrom } from 'rxjs';
 
 @Injectable()
 export class BypassService {
@@ -20,6 +21,7 @@ export class BypassService {
   constructor(
     private readonly logger: Logger,
     private readonly configService: ConfigService,
+    private httpService: HttpService,
   ) {
     this.bypass =
       this.configService.get<string>('app.env') !== 'production' &&
@@ -109,7 +111,9 @@ export class BypassService {
     return user;
   }
   
-  async getMockRoles(userId: string): Promise<string[]> {
+  async getMockRoles(
+    userId: string,
+  ): Promise<string[]> {
 	  
 	const mockPermissionObject = await this.getMockPermissionObject();
 	

--- a/src/oidc/Bypass.service.ts
+++ b/src/oidc/Bypass.service.ts
@@ -111,11 +111,9 @@ export class BypassService {
     return user;
   }
   
-  async getMockRoles(
-    userId: string,
-  ): Promise<string[]> {
+  getMockRoles(userId: string) {
 	  
-	const mockPermissionObject = await this.getMockPermissionObject();
+	const mockPermissionObject = this.getMockPermissionObject();
 	
 	//filter out all the unmactched records
     const userPermissions = mockPermissionObject.filter(

--- a/src/oidc/Bypass.service.ts
+++ b/src/oidc/Bypass.service.ts
@@ -112,35 +112,31 @@ export class BypassService {
   }
   
   async getMockRoles(userId: string): Promise<string[]> {
-	  
+    
 	const mockPermissionObject = await this.getMockPermissionObject();
-	
-	//filter out all the unmactched records
+    
+	//Filter out all the unmatched records
     const userPermissions = mockPermissionObject.filter(
-      entry => entry.userId.toUpperCase() === userId.toUpperCase(),
+      (entry) => entry.userId.toUpperCase() === userId.toUpperCase(),
     );
     
-    //only retrieve info from the first matched record
-    if (
-      userPermissions.length > 0 &&
-      userPermissions[0]?.roles?.length > 0
-    ) {
-      //test roles are defined for this user
-	  // return test roles
-	  return userPermissions[0].roles;
+	//Only retrieve info from the first matched record
+    if (userPermissions.length > 0 && userPermissions[0]?.roles?.length > 0) {
+      //Test roles are defined for this user
+      // return test roles
+      return userPermissions[0].roles;
+    } else {
+      //Test roles are not defined for this user
+      // return all possible roles
+      return [
+        UserRole.SPONSOR,
+        UserRole.PREPARER,
+        UserRole.SUBMITTER,
+        UserRole.ANALYST,
+        UserRole.ADMIN,
+        UserRole.INITIAL_AUTHORIZER,
+      ];
     }
-	else {		
-	  //test roles are not defined for this user
-	  // return all possible roles
-	  return [
-		UserRole.SPONSOR,
-		UserRole.PREPARER,
-		UserRole.SUBMITTER,
-		UserRole.ANALYST,
-		UserRole.ADMIN,
-		UserRole.INITIAL_AUTHORIZER,
-	  ];
-	}
   }
 
   async getMockPermissionObject(): Promise<MockPermissionObject[]> {

--- a/src/oidc/Bypass.service.ts
+++ b/src/oidc/Bypass.service.ts
@@ -10,6 +10,8 @@ import { decode, encode } from 'js-base64';
 import { TokenDTO } from '../dtos/token.dto';
 import { UserDTO } from '../dtos/user.dto';
 
+import { MockPermissionObject } from '/../interfaces/mock-permissions.interface';
+
 @Injectable()
 export class BypassService {
   private bypass = false;
@@ -47,15 +49,8 @@ export class BypassService {
     user.firstName = userId;
     user.email = this.configService.get<string>('cdxBypass.userEmail');
     user.lastName = '';
-    // we can update the roles for bypass user for testing purpose
-    user.roles = [
-      UserRole.SPONSOR,
-      UserRole.PREPARER,
-      UserRole.SUBMITTER,
-      UserRole.ANALYST,
-      UserRole.ADMIN,
-      UserRole.INITIAL_AUTHORIZER,
-    ];
+	
+    user.roles = await this.getMockRoles();
 
     return user;
   }
@@ -111,5 +106,52 @@ export class BypassService {
     });
 
     return user;
+  }
+  
+  async getMockRoles(): Promise<Array<string>> {
+	  
+	const mockPermissionObject = await this.getMockPermissionObject();
+	
+	//filter out all the unmactched records
+    const userPermissions = mockPermissionObject.filter(
+      entry => entry.userId.toUpperCase() === userId.toUpperCase(),
+    );
+    
+    //only retrieve info from the first matched record
+    if (
+      userPermissions.length > 0 &&
+      userPermissions[0]?.roles?.length > 0
+    ) {
+      //test roles are defined for this user
+	  // return test roles
+	  return userPermissions[0].roles;
+    }
+	else {		
+	  //test roles are not defined for this user
+	  // return all possible roles
+	  return [
+		UserRole.SPONSOR,
+		UserRole.PREPARER,
+		UserRole.SUBMITTER,
+		UserRole.ANALYST,
+		UserRole.ADMIN,
+		UserRole.INITIAL_AUTHORIZER,
+	  ];
+	}
+  }
+
+  async getMockPermissionObject(): Promise<MockPermissionObject[]> {
+
+    const contentUri = this.configService.get<string>('app.contentUri');
+    
+    try {
+      const url = `${contentUri}/auth/mockPermissions.json`;
+      const mockPermissionResult = await firstValueFrom(
+        this.httpService.get(url),
+      );
+      return mockPermissionResult.data;
+    } catch (e) {
+      throw new EaseyException(e, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
   }
 }

--- a/src/oidc/Bypass.service.ts
+++ b/src/oidc/Bypass.service.ts
@@ -111,7 +111,7 @@ export class BypassService {
     return user;
   }
   
-  async getMockRoles(userId: string): Promise<> {
+  async getMockRoles(userId: string): Promise<object> {
 	  
 	const mockPermissionObject = await this.getMockPermissionObject();
 	

--- a/src/oidc/Bypass.service.ts
+++ b/src/oidc/Bypass.service.ts
@@ -111,9 +111,9 @@ export class BypassService {
     return user;
   }
   
-  getMockRoles(userId: string) {
+  async getMockRoles(userId: string): Promise<> {
 	  
-	const mockPermissionObject = this.getMockPermissionObject();
+	const mockPermissionObject = await this.getMockPermissionObject();
 	
 	//filter out all the unmactched records
     const userPermissions = mockPermissionObject.filter(

--- a/src/oidc/Bypass.service.ts
+++ b/src/oidc/Bypass.service.ts
@@ -111,7 +111,7 @@ export class BypassService {
     return user;
   }
   
-  async getMockRoles(userId: string): Promise<object> {
+  async getMockRoles(userId: string): Promise<string[]> {
 	  
 	const mockPermissionObject = await this.getMockPermissionObject();
 	
@@ -127,7 +127,7 @@ export class BypassService {
     ) {
       //test roles are defined for this user
 	  // return test roles
-	  return userPermissions[0].roles;
+	  return userPermissions[0].roles as string[];
     }
 	else {		
 	  //test roles are not defined for this user
@@ -139,7 +139,7 @@ export class BypassService {
 		UserRole.ANALYST,
 		UserRole.ADMIN,
 		UserRole.INITIAL_AUTHORIZER,
-	  ];
+	  ] as string[];
 	}
   }
 

--- a/src/permissions/Permissions.service.spec.ts
+++ b/src/permissions/Permissions.service.spec.ts
@@ -50,7 +50,7 @@ jest.mock('rxjs', () => {
           },
         ],
         missingCertificationStatements: true,
-		roles: [UserRole.PREPARER],
+		roles: ["Preparer"],
       },
     }),
   };

--- a/src/permissions/Permissions.service.spec.ts
+++ b/src/permissions/Permissions.service.spec.ts
@@ -97,11 +97,11 @@ describe('PermissionsService', () => {
 				  userId: 'user',
 			      facilities: [
     			    {
-			  	      id: 1,
+			  	      facId: 1,
 				      permissions: ['DSMP', 'DSEM', 'DSQA'],
 				    },
 				    {
-				      id: 2,
+				      facId: 2,
 				      permissions: ['DSMP', 'DSEM'],
 				    },
 			      ],

--- a/src/permissions/Permissions.service.spec.ts
+++ b/src/permissions/Permissions.service.spec.ts
@@ -38,8 +38,7 @@ jest.mock('rxjs', () => {
     firstValueFrom: jest.fn().mockResolvedValue({
       data: {
         userId: 'user',
-        isAdmin: false,
-        plantList: [
+        facilities: [
           {
             id: 1,
             permissions: ['DSMP', 'DSEM', 'DSQA'],
@@ -95,8 +94,7 @@ describe('PermissionsService', () => {
 			  [
 			    {
 				  userId: 'user',
-			      isAdmin: false,
-			      plantList: [
+			      facilities: [
     			    {
 			  	      id: 1,
 				      permissions: ['DSMP', 'DSEM', 'DSQA'],

--- a/src/permissions/Permissions.service.spec.ts
+++ b/src/permissions/Permissions.service.spec.ts
@@ -92,20 +92,24 @@ describe('PermissionsService', () => {
             bypassEnabled: jest.fn().mockReturnValue(false),
             getBypassUser: jest.fn(),
 			getMockPermissionObject: jest.fn().mockReturnValue({
-			  userId: 'user',
-			  isAdmin: false,
-			  plantList: [
+			  [
 			    {
-			  	  id: 1,
-				  permissions: ['DSMP', 'DSEM', 'DSQA'],
-				},
-				{
-				  id: 2,
-				  permissions: ['DSMP', 'DSEM'],
-				},
-			  ],
-			  missingCertificationStatements: true,
-			  roles: [UserRole.PREPARER],
+				  userId: 'user',
+			      isAdmin: false,
+			      plantList: [
+    			    {
+			  	      id: 1,
+				      permissions: ['DSMP', 'DSEM', 'DSQA'],
+				    },
+				    {
+				      id: 2,
+				      permissions: ['DSMP', 'DSEM'],
+				    },
+			      ],
+			      missingCertificationStatements: true,
+			      roles: [UserRole.PREPARER],
+			    }
+			  ]
 			}),
           },
         },

--- a/src/permissions/Permissions.service.spec.ts
+++ b/src/permissions/Permissions.service.spec.ts
@@ -10,6 +10,7 @@ import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { OidcHelperService } from '../oidc/OidcHelperService';
 import { BypassService } from '../oidc/Bypass.service';
 import { FacilityAccessWithCertStatementFlagDTO } from '../dtos/permissions.dto';
+import { UserRole } from '@us-epa-camd/easey-common/enums';
 
 let responseVals = {
   ['app.env']: 'production',
@@ -37,7 +38,7 @@ jest.mock('rxjs', () => {
     firstValueFrom: jest.fn().mockResolvedValue({
       data: {
         userId: 'user',
-        isAdmin: true,
+        isAdmin: false,
         plantList: [
           {
             id: 1,
@@ -49,6 +50,7 @@ jest.mock('rxjs', () => {
           },
         ],
         missingCertificationStatements: true,
+		roles: [UserRole.PREPARER],
       },
     }),
   };
@@ -89,6 +91,24 @@ describe('PermissionsService', () => {
           useValue: {
             bypassEnabled: jest.fn().mockReturnValue(false),
             getBypassUser: jest.fn(),
+			getMockPermissionObject: jest.fn().mockReturnValue({
+			  {
+				userId: 'user',
+				isAdmin: false,
+				plantList: [
+				  {
+					id: 1,
+					permissions: ['DSMP', 'DSEM', 'DSQA'],
+				  },
+				  {
+					id: 2,
+					permissions: ['DSMP', 'DSEM'],
+				  },
+				],
+				missingCertificationStatements: true,
+				roles: [UserRole.PREPARER],
+			  }
+			}),
           },
         },
         {
@@ -126,7 +146,7 @@ describe('PermissionsService', () => {
       const permissions = await service.getUserPermissions('', '', '');
       expect(permissions).toEqual({
         userId: 'user',
-        isAdmin: true,
+        isAdmin: false,
         plantList: [
           {
             id: 1,
@@ -138,6 +158,7 @@ describe('PermissionsService', () => {
           },
         ],
         missingCertificationStatements: true,
+		roles: [UserRole.PREPARER],
       });
     });
   });
@@ -202,6 +223,35 @@ describe('PermissionsService', () => {
       );
       expect(facilities?.plantList).toEqual([]);
       expect(facilities?.missingCertificationStatements).toEqual(true);
+    });
+  });
+
+  describe('getMockPermissions', () => {
+    it('should error in production', async () => {
+      await expect(service.getMockPermissions('')).rejects.toThrowError(
+        EaseyException,
+      );
+    });
+    it('should parse user env var and build the permissions properly given a found user', async () => {
+      responseVals = {
+        ...responseVals,
+        ['app.env']: 'local-dev',
+      };
+
+      const permissions = await service.getMockPermissions('user');
+
+      expect(permissions.plantList[0].facId).toEqual(1);
+    });
+
+    it('should parse user env var and build the permissions properly given a not found user', async () => {
+      responseVals = {
+        ...responseVals,
+        ['app.env']: 'local-dev',
+      };
+
+      const permissions = await service.getMockPermissions('userNotFound');
+
+      expect(permissions).toBe(null);
     });
   });
 });

--- a/src/permissions/Permissions.service.spec.ts
+++ b/src/permissions/Permissions.service.spec.ts
@@ -91,7 +91,7 @@ describe('PermissionsService', () => {
           useValue: {
             bypassEnabled: jest.fn().mockReturnValue(false),
             getBypassUser: jest.fn(),
-			getMockPermissionObject: jest.fn().mockReturnValue({{
+			getMockPermissionObject: jest.fn().mockReturnValue(
 			  [
 			    {
 				  userId: 'user',
@@ -110,7 +110,7 @@ describe('PermissionsService', () => {
 			      roles: [UserRole.PREPARER],
 			    }
 			  ]
-			}}),
+			),
           },
         },
         {

--- a/src/permissions/Permissions.service.spec.ts
+++ b/src/permissions/Permissions.service.spec.ts
@@ -91,7 +91,7 @@ describe('PermissionsService', () => {
           useValue: {
             bypassEnabled: jest.fn().mockReturnValue(false),
             getBypassUser: jest.fn(),
-			getMockPermissionObject: jest.fn().mockReturnValue({
+			getMockPermissionObject: jest.fn().mockReturnValue({{
 			  [
 			    {
 				  userId: 'user',
@@ -110,7 +110,7 @@ describe('PermissionsService', () => {
 			      roles: [UserRole.PREPARER],
 			    }
 			  ]
-			}),
+			}}),
           },
         },
         {

--- a/src/permissions/Permissions.service.spec.ts
+++ b/src/permissions/Permissions.service.spec.ts
@@ -38,7 +38,8 @@ jest.mock('rxjs', () => {
     firstValueFrom: jest.fn().mockResolvedValue({
       data: {
         userId: 'user',
-        facilities: [
+		isAdmin: false,
+        plantList: [
           {
             id: 1,
             permissions: ['DSMP', 'DSEM', 'DSQA'],

--- a/src/permissions/Permissions.service.spec.ts
+++ b/src/permissions/Permissions.service.spec.ts
@@ -92,22 +92,20 @@ describe('PermissionsService', () => {
             bypassEnabled: jest.fn().mockReturnValue(false),
             getBypassUser: jest.fn(),
 			getMockPermissionObject: jest.fn().mockReturnValue({
-			  {
-				userId: 'user',
-				isAdmin: false,
-				plantList: [
-				  {
-					id: 1,
-					permissions: ['DSMP', 'DSEM', 'DSQA'],
-				  },
-				  {
-					id: 2,
-					permissions: ['DSMP', 'DSEM'],
-				  },
-				],
-				missingCertificationStatements: true,
-				roles: [UserRole.PREPARER],
-			  }
+			  userId: 'user',
+			  isAdmin: false,
+			  plantList: [
+			    {
+			  	  id: 1,
+				  permissions: ['DSMP', 'DSEM', 'DSQA'],
+				},
+				{
+				  id: 2,
+				  permissions: ['DSMP', 'DSEM'],
+				},
+			  ],
+			  missingCertificationStatements: true,
+			  roles: [UserRole.PREPARER],
 			}),
           },
         },

--- a/src/permissions/Permissions.service.spec.ts
+++ b/src/permissions/Permissions.service.spec.ts
@@ -204,46 +204,4 @@ describe('PermissionsService', () => {
       expect(facilities?.missingCertificationStatements).toEqual(true);
     });
   });
-
-  describe('getMockPermissions', () => {
-    it('should error in production', async () => {
-      await expect(service.getMockPermissions('')).rejects.toThrowError(
-        EaseyException,
-      );
-    });
-    it('should parse user env var and build the permissions properly given a found user', async () => {
-      const p: MockPermissionObject = {
-        userId: 'user',
-        facilities: [{ orisCode: 1, roles: [], facId: 1 }],
-        missingCertificationStatements: true,
-      };
-      jest.spyOn(service.bypassService, 'getMockPermissionObject').mockResolvedValue([p]);
-      responseVals = {
-        ...responseVals,
-        ['app.env']: 'local-dev',
-      };
-
-      const permissions = await service.getMockPermissions('user');
-
-      expect(permissions.plantList[0].facId).toEqual(1);
-    });
-
-    it('should parse user env var and build the permissions properly given a not found user', async () => {
-      const p: MockPermissionObject = {
-        userId: 'user',
-        facilities: [{ orisCode: 1, roles: [], facId: 1 }],
-        missingCertificationStatements: true,
-      };
-      responseVals = {
-        ...responseVals,
-        ['app.env']: 'local-dev',
-      };
-
-      jest.spyOn(service.bypassService, 'getMockPermissionObject').mockResolvedValue([p]);
-
-      const permissions = await service.getMockPermissions('userNotFound');
-
-      expect(permissions).toBe(null);
-    });
-  });
 });

--- a/src/permissions/Permissions.service.spec.ts
+++ b/src/permissions/Permissions.service.spec.ts
@@ -217,7 +217,7 @@ describe('PermissionsService', () => {
         facilities: [{ orisCode: 1, roles: [], facId: 1 }],
         missingCertificationStatements: true,
       };
-      jest.spyOn(service, 'getMockPermissionObject').mockResolvedValue([p]);
+      jest.spyOn(service.bypassService, 'getMockPermissionObject').mockResolvedValue([p]);
       responseVals = {
         ...responseVals,
         ['app.env']: 'local-dev',
@@ -239,7 +239,7 @@ describe('PermissionsService', () => {
         ['app.env']: 'local-dev',
       };
 
-      jest.spyOn(service, 'getMockPermissionObject').mockResolvedValue([p]);
+      jest.spyOn(service.bypassService, 'getMockPermissionObject').mockResolvedValue([p]);
 
       const permissions = await service.getMockPermissions('userNotFound');
 

--- a/src/permissions/Permissions.service.ts
+++ b/src/permissions/Permissions.service.ts
@@ -135,7 +135,7 @@ export class PermissionsService {
     }
 
     const permissionsDto = {plantList: [], missingCertificationStatements: true,} as FacilityAccessWithCertStatementFlagDTO;
-    const mockPermissionObject = await this.getMockPermissionObject();
+    const mockPermissionObject = await this.bypassService.getMockPermissionObject();
 
     //filter out all the unmactched records
     const userPermissions = mockPermissionObject.filter(
@@ -212,21 +212,6 @@ export class PermissionsService {
           HttpStatus.INTERNAL_SERVER_ERROR,
         );
       }
-      throw new EaseyException(e, HttpStatus.INTERNAL_SERVER_ERROR);
-    }
-  }
-
-  async getMockPermissionObject(): Promise<MockPermissionObject[]> {
-
-    const contentUri = this.configService.get<string>('app.contentUri');
-    
-    try {
-      const url = `${contentUri}/auth/mockPermissions.json`;
-      const mockPermissionResult = await firstValueFrom(
-        this.httpService.get(url),
-      );
-      return mockPermissionResult.data;
-    } catch (e) {
       throw new EaseyException(e, HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }


### PR DESCRIPTION
 - add getMockRoles to BypassService - reads roles from mockPermissions file
 - move getMockPermissionObject to BypassService (from PermissionsService) - now needed/accessible by both BypassService and PermissionsService
 - add roles as optional element to mock permissions interface
 - update getBypassUser to use roles provided in mockPermissions (default to all roles if no roles are defined for the user in mockPermissions)
