### PR TITLE
 Add configurable client IP validation to resolve local development authentication issues

### DIFF
--- a/manifest-vars.yml
+++ b/manifest-vars.yml
@@ -19,6 +19,7 @@ mockPermissionsEnabled: false
 enableAllFacilities: true
 maintenanceBypassUsers: '[]'
 enableAuditLog: true
+disableClientIpValidation: true
 healthCheckInterval: 30
 healthCheckInvocationTimeout: 60
 dbHealthTimeout: 5000

--- a/manifest-vars.yml
+++ b/manifest-vars.yml
@@ -19,7 +19,6 @@ mockPermissionsEnabled: false
 enableAllFacilities: true
 maintenanceBypassUsers: '[]'
 enableAuditLog: true
-disableClientIpValidation: true
 healthCheckInterval: 30
 healthCheckInvocationTimeout: 60
 dbHealthTimeout: 5000

--- a/manifest.yml
+++ b/manifest.yml
@@ -39,6 +39,7 @@ applications:
       EASEY_AUTH_API_ENABLE_ALL_FACILITIES: ((enableAllFacilities))
       TZ: America/New_York
       EASEY_AUTH_API_ENABLE_AUDIT_LOG: ((enableAuditLog))
+      EASEY_AUTH_API_DISABLE_CLIENT_IP_VALIDATION: ((disableClientIpValidation))
       EASEY_DB_HEALTH_TIMEOUT: ((dbHealthTimeout))
 
       # ICAM

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -116,5 +116,6 @@ export default registerAs('app', () => ({
     false,
   ),
   maintenanceBypassUsers: JSON.parse(getConfigValue('EASEY_MAINTENANCE_BYPASS_USERS', '[]')),
-  enableAuditLog: getConfigValueBoolean('EASEY_AUTH_API_ENABLE_AUDIT_LOG', true)
+  enableAuditLog: getConfigValueBoolean('EASEY_AUTH_API_ENABLE_AUDIT_LOG', true),
+  disableClientIpValidation: getConfigValueBoolean('EASEY_AUTH_API_DISABLE_CLIENT_IP_VALIDATION', false),
 }));

--- a/src/token/token.service.ts
+++ b/src/token/token.service.ts
@@ -119,9 +119,11 @@ export class TokenService {
   }
 
   async validateClientIp(user: CurrentUser, clientIp: string) {
-    // Skip IP validation if disabled in configuration
+    // Skip IP validation if disabled in configuration (but never in production)
     const disableIpValidation = this.configService.get<boolean>('app.disableClientIpValidation');
-    if (disableIpValidation) {
+    const isProduction = this.configService.get<string>('app.env') === 'production';
+    
+    if (disableIpValidation && !isProduction) {
       this.logger.debug('Client IP validation is disabled');
       return;
     }

--- a/src/token/token.service.ts
+++ b/src/token/token.service.ts
@@ -119,11 +119,18 @@ export class TokenService {
   }
 
   async validateClientIp(user: CurrentUser, clientIp: string) {
+    // Skip IP validation if disabled in configuration
+    const disableIpValidation = this.configService.get<boolean>('app.disableClientIpValidation');
+    if (disableIpValidation) {
+      this.logger.debug('Client IP validation is disabled');
+      return;
+    }
+
     if (user.clientIp !== clientIp) {
       throw new EaseyException(
         new Error('Request coming from invalid IP address'),
         HttpStatus.BAD_REQUEST,
-        { userId: user.userId, clientIp: clientIp },
+        { userId: user.userId, clientIp: clientIp, storedIp: user.clientIp },
       );
     }
   }


### PR DESCRIPTION
 Add configurable client IP validation to resolve local development authentication issues

  **Problem**:
  When running ECMPS UI locally while pointing to backend APIs in the dev environment, authentication fails because auth-API enforces strict IP address validation. The IP stored during initial login (local) doesn't match the IP seen by the backend APIs in the dev environment, causing token validation to fail with "Request coming from invalid IP address" errors. This forces developers to run all backend-apis locally even if they are just working to fix one backend-api or even just ecmps ui.

  **Solution**:
  - Add EASEY_AUTH_API_DISABLE_CLIENT_IP_VALIDATION environment variable with secure default (false)
  - Update TokenService.validateClientIp() to conditionally skip IP validation when disabled

  This allows local development against remote APIs. Developers will only be forced to run auth-api locally (and any specific APIs they are testing locally).