### PR TITLE
Need disableClientIpValidation at least in manifest-vars.yml

### DIFF
--- a/manifest-vars.yml
+++ b/manifest-vars.yml
@@ -36,3 +36,4 @@ oidcCdxTokenEndpoint: https://icamauthdev.epacdx.net/cdxidbridgedev.onmicrosoft.
 oidcCdxLogoutEndpoint: https://icamauthdev.epacdx.net/cdxidbridgedev.onmicrosoft.com/%s/oauth2/v2.0/logout
 oidcCdxJwksUri: https://icamauthdev.epacdx.net/cdxidbridgedev.onmicrosoft.com/%s/discovery/v2.0/keys
 oidcCdxTokenIssuer: https://icamauthdev.epacdx.net/ebb0f696-0af0-431f-9327-b6a5c27946ae/v2.0/
+disableClientIpValidation: false


### PR DESCRIPTION
Need disableClientIpValidation at least in manifest-vars.yml to avoid deploy errors.

