### PR TITLE
Fix race condition in token refresh by deduplicating requests 

### DIFF
--- a/src/token/token.service.ts
+++ b/src/token/token.service.ts
@@ -25,8 +25,8 @@ import { MaintenanceVerifyParamDTO } from '../dtos/maintenance-verify-param.dto'
 export class TokenService {
   private jwksClients = new Map<string, JwksClient>();
 
-  //used to keep track of ongoing refreshToken executions keyed by session.sessionId.
-  private readonly sessionPromises = new Map<string, Promise<TokenDTO>>();
+  //used to keep track of ongoing refreshToken executions keyed by token to prevent race conditions
+  private readonly tokenRefreshPromises = new Map<string, Promise<TokenDTO>>();
 
   constructor(
     private configService: ConfigService,
@@ -40,34 +40,35 @@ export class TokenService {
   async refreshToken(userId: string, token: string, clientIp: string) {
     this.logger.debug('Starting refreshToken process', { userId, clientIp });
 
-    //Grab the current session data
-    let session: UserSession = await this.userSessionService.findSessionByUserIdAndToken(
-      userId,
-      token,
-    );
-
-    if (!session) {
-      throw new EaseyException(
-        new Error('Unable to refresh token, no existing session for user/token '),
-        HttpStatus.BAD_REQUEST,
-        { userId: userId },
-      );
-    }
-
-    this.logger.debug('Retrieved user session', { sessionId: session.sessionId, });
-
-    //If a request comes in for a session that is already being processed, wait for promise to resolve.
-    const sessionId = session.sessionId;
-    if (this.sessionPromises.has(sessionId)) {
+    // Check if a refresh is already in progress for this token (prevents race conditions)
+    if (this.tokenRefreshPromises.has(token)) {
       this.logger.debug(
-        'Waiting for existing refreshToken process to complete',
-        { sessionId },
+        'Refresh already in progress for this token, waiting for completion',
+        { userId },
       );
-      return this.sessionPromises.get(sessionId);
+      return this.tokenRefreshPromises.get(token);
     }
 
+    // Create a promise for this refresh operation
     const refreshPromise = (async () => {
       try {
+        //Grab the current session data
+        let session: UserSession = await this.userSessionService.findSessionByUserIdAndToken(
+          userId,
+          token,
+        );
+
+        if (!session) {
+          throw new EaseyException(
+            new Error('Unable to refresh token, no existing session for user/token '),
+            HttpStatus.BAD_REQUEST,
+            { userId: userId },
+          );
+        }
+
+        this.logger.debug('Retrieved user session', { sessionId: session.sessionId, });
+
+        const sessionId = session.sessionId;
 
         if (this.bypassService.bypassEnabled()) {
           //Bypass Tokens
@@ -105,17 +106,17 @@ export class TokenService {
         authToken.expiration = session.tokenExpiration;
 
         return authToken;
-      } catch (error) {
-        this.sessionPromises.delete(sessionId);
-        throw error;
+      } finally {
+        // Always clean up the token-level promise when done (success or error)
+        this.tokenRefreshPromises.delete(token);
       }
     })();
 
-    this.sessionPromises.set(sessionId, refreshPromise);
-    const authToken = await refreshPromise;
-    this.sessionPromises.delete(sessionId); //promise resolved, removes from the map.
+    // Store the promise keyed by token
+    this.tokenRefreshPromises.set(token, refreshPromise);
 
-    return authToken;
+    // Return the promise
+    return refreshPromise;
   }
 
   private async validateClientIp(user: CurrentUser, clientIp: string) {


### PR DESCRIPTION
Fix race condition in token refresh by deduplicating requests before session lookup. Changed deduplication from sessionId-keyed (after session lookup) to token-keyed (before session lookup) to prevent concurrent refresh requests from failing when the first request rotates the token.
