### PR TITLE
Fix/6950 read replica default mode

### DIFF
--- a/src/config/typeorm.config.ts
+++ b/src/config/typeorm.config.ts
@@ -37,6 +37,7 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
         entities: [__dirname + '/../**/*.entity.{js,ts}'],
         synchronize: false,
         replication: {
+          defaultMode: 'master',
           master: {
             host: this.configService.get<string>('database.host'),
             port: this.configService.get<number>('database.port'),


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6950

## Main Changes:

- Set the replication default mode to "master". If this is not specified, but replication is configured, the default mode will be "slave", meaning all read operations will be sent to the replica by default.