### PR TITLE
Feature/7290 CAPAS POST switch

### DIFF
--- a/manifest-vars.beta.yml
+++ b/manifest-vars.beta.yml
@@ -5,6 +5,7 @@ apiHost: api.epa.gov/easey/beta
 cdxSvcs: https://testngn.epacdxnode.net/cdx-register-II/services
 naasSvcs: https://naas.epacdxnode.net/xml/securitytoken_v30.wsdl
 permissionsUrl: https://cbsprodbeta.epa.gov/CBS/api/auth-mgmt/responsibilities
+permissionsMethod: GET
 dataFlow: EASEY Beta
 enableAllFacilities: false
 mockPermissionsEnabled: false

--- a/manifest-vars.perf.yml
+++ b/manifest-vars.perf.yml
@@ -6,6 +6,7 @@ cdxSvcs: https://testngn.epacdxnode.net/cdx-register-II/services
 naasSvcs: https://naas.epacdxnode.net/xml/securitytoken_v30.wsdl
 # currently using CBS DEV for perf testing which is pointing to perf api's
 permissionsUrl: https://cbsstagei.epa.gov/CBSD/api/auth-mgmt/responsibilities
+permissionsMethod: GET
 dataFlow: EASEY Performance
 mockPermissionsEnabled: false
 enableAllFacilities: true

--- a/manifest-vars.prod.yml
+++ b/manifest-vars.prod.yml
@@ -5,6 +5,7 @@ apiHost: api.epa.gov/easey
 cdxSvcs: https://cdxnodengn.epa.gov/cdx-register-II/services
 naasSvcs: https://cdxnodenaas.epa.gov/xml/securitytoken_v30.wsdl
 permissionsUrl: https://camd.epa.gov/CBS/api/auth-mgmt/responsibilities
+permissionsMethod: GET
 dataFlow: EASEY
 mockPermissionsEnabled: false
 enableAllFacilities: false

--- a/manifest-vars.staging.yml
+++ b/manifest-vars.staging.yml
@@ -5,6 +5,7 @@ apiHost: api.epa.gov/easey/staging
 cdxSvcs: https://testngn.epacdxnode.net/cdx-register-II/services
 naasSvcs: https://naas.epacdxnode.net/xml/securitytoken_v30.wsdl
 permissionsUrl: https://cbsstagei.epa.gov/CBS/api/auth-mgmt/responsibilities
+permissionsMethod: GET
 dataFlow: EASEY Test
 maintenanceBypassUsers: '[]'
 enableAuditLog: true

--- a/manifest-vars.test.yml
+++ b/manifest-vars.test.yml
@@ -5,6 +5,7 @@ apiHost: api.epa.gov/easey/test
 cdxSvcs: https://testngn.epacdxnode.net/cdx-register-II/services
 naasSvcs: https://naas.epacdxnode.net/xml/securitytoken_v30.wsdl
 permissionsUrl: https://cbsstagei.epa.gov/CBS/api/auth-mgmt/responsibilities
+permissionsMethod: GET
 dataFlow: EASEY Test
 maintenanceBypassUsers: '[]'
 enableAuditLog: true

--- a/manifest-vars.yml
+++ b/manifest-vars.yml
@@ -14,6 +14,7 @@ dbSvc: camd-pg-db
 cdxSvcs: https://devngn.epacdxnode.net/cdx-register-II/services
 naasSvcs: https://naasdev.epacdxnode.net/xml/securitytoken_v30.wsdl
 permissionsUrl: https://cbsstagei.epa.gov/CBSD/api/auth-mgmt/responsibilities
+permissionsMethod: GET
 dataFlow: EASEY
 mockPermissionsEnabled: false
 enableAllFacilities: true

--- a/manifest.yml
+++ b/manifest.yml
@@ -35,6 +35,7 @@ applications:
       EASEY_AUTH_CONTENT_API: https://((apiHost))/content-mgmt
       EASEY_AUTH_API_MOCK_PERMISSIONS_URL: https://((apiHost))/auth-mgmt/permissions
       EASEY_AUTH_API_PERMISSIONS_URL: ((permissionsUrl))
+      EASEY_AUTH_API_PERMISSIONS_METHOD: ((permissionsMethod))
       EASEY_AUTH_API_MOCK_PERMISSIONS_ENABLED: ((mockPermissionsEnabled))
       EASEY_AUTH_API_DATA_FLOW: ((dataFlow))
       EASEY_AUTH_API_ENABLE_ALL_FACILITIES: ((enableAllFacilities))

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -88,6 +88,8 @@ export default registerAs('app', () => ({
     'EASEY_AUTH_API_PERMISSIONS_URL',
     'https://cbsstagei.rtpnc.epa.gov/CBSD/api/auth-mgmt/responsibilities',
   ),
+  // HTTP verb for the permissions endpoint: 'GET' or 'POST'. Defaults to GET.
+  permissionsMethod: getConfigValue('EASEY_AUTH_API_PERMISSIONS_METHOD', 'GET'),
   contentUri: getConfigValue(
     'EASEY_AUTH_CONTENT_API',
     'https://api.epa.gov/easey/dev/content-mgmt',

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -88,7 +88,6 @@ export default registerAs('app', () => ({
     'EASEY_AUTH_API_PERMISSIONS_URL',
     'https://cbsstagei.rtpnc.epa.gov/CBSD/api/auth-mgmt/responsibilities',
   ),
-  // HTTP verb for the permissions endpoint: 'GET' or 'POST'. Defaults to GET.
   permissionsMethod: getConfigValue('EASEY_AUTH_API_PERMISSIONS_METHOD', 'GET'),
   contentUri: getConfigValue(
     'EASEY_AUTH_CONTENT_API',

--- a/src/permissions/Permissions.service.ts
+++ b/src/permissions/Permissions.service.ts
@@ -194,8 +194,6 @@ export class PermissionsService {
       };
       // Non-POST falls back to GET
       const method = this.configService.get<string>('app.permissionsMethod');
-      // TODO: confirm POST payload contract with the API owner. Today userId is
-      // appended to `url` as a query param; the POST endpoint may expect it in the body.
       const permissionResult = await firstValueFrom(
         method === 'POST'
           ? this.httpService.post(url, {}, requestConfig)

--- a/src/permissions/Permissions.service.ts
+++ b/src/permissions/Permissions.service.ts
@@ -184,15 +184,22 @@ export class PermissionsService {
           secureOptions: crypto.constants.SSL_OP_LEGACY_SERVER_CONNECT,
         }),
       };
+      const requestConfig = {
+        ...allowLegacyRenegotiationforNodeJsOptions,
+        headers: {
+          'x-api-key': this.configService.get<string>('app.apiKey'),
+          'x-forwarded-for': clientIp,
+          Authorization: `Bearer ${token}`,
+        },
+      };
+      // Non-POST falls back to GET
+      const method = this.configService.get<string>('app.permissionsMethod');
+      // TODO: confirm POST payload contract with the API owner. Today userId is
+      // appended to `url` as a query param; the POST endpoint may expect it in the body.
       const permissionResult = await firstValueFrom(
-        this.httpService.get(url, {
-          ...allowLegacyRenegotiationforNodeJsOptions,
-          headers: {
-            'x-api-key': this.configService.get<string>('app.apiKey'),
-            'x-forwarded-for': clientIp,
-            Authorization: `Bearer ${token}`,
-          },
-        }),
+        method === 'POST'
+          ? this.httpService.post(url, {}, requestConfig)
+          : this.httpService.get(url, requestConfig),
       );
 
       if (permissionResult.data) {


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/7290

## Main Changes:

- Add an environment variable to drive the HTTP verb used for the requests in the `PermissionsService`. This will need to be set to POST when the target is changed from the CBS service to the CAPAS service.